### PR TITLE
Update URL to calico.yaml

### DIFF
--- a/networking/calico.sh
+++ b/networking/calico.sh
@@ -4,7 +4,7 @@ export KUBECONFIG=/etc/kubernetes/admin.conf
 curl -q -O -L  https://github.com/projectcalico/calicoctl/releases/download/v3.14.1/calicoctl
 chmod +x calicoctl
 mv calicoctl /usr/local/bin/calicoctl
-kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/master/manifests/calico.yaml
 
 # create 2 subnet pools
 /usr/local/bin/calicoctl apply -f - <<EOT


### PR DESCRIPTION
I'm able to apply `calico.yaml` now, project calico changed their documentation url to tigera.io so I'm pointing to their git repo instead.

`vagrant up` moves past this now but I'm failing at the last step to pull the images, is the error related?

here are my [logs](https://github.com/nfisher/k8smulti/files/10861902/logs.txt)
